### PR TITLE
WebDriverBase extension wasn't updated to reflect naming change

### DIFF
--- a/PHPWebDriver/WebDriverStorage.php
+++ b/PHPWebDriver/WebDriverStorage.php
@@ -62,7 +62,7 @@ abstract class PHPWebDriver_WebDriverStorage extends PHPWebDriver_WebDriverBase
             return $this->getKey(func_get_arg(0));
         }
 
-        throw new UnhandledWebDriverError;
+        throw new PHPWebDriver_UnhandledWebDriverError;
     }
 
     /**
@@ -92,7 +92,7 @@ abstract class PHPWebDriver_WebDriverStorage extends PHPWebDriver_WebDriverBase
             return $this;
         }
 
-        throw new UnhandledWebDriverError;
+        throw new PHPWebDriver_UnhandledWebDriverError;
     }
 
     /**
@@ -116,7 +116,7 @@ abstract class PHPWebDriver_WebDriverStorage extends PHPWebDriver_WebDriverBase
             return $this->deleteKey(func_get_arg(0));
         }
 
-        throw new UnhandledWebDriverError;
+        throw new PHPWebDriver_UnhandledWebDriverError;
     }
 
     /**

--- a/PHPWebDriver/WebDriverStorage.php
+++ b/PHPWebDriver/WebDriverStorage.php
@@ -28,7 +28,7 @@
  * @method void deleteKey($key) Delete a specific key.
  * @method integer size() Get the number of items in the storage.
  */
-abstract class PHPWebDriver_WebDriverStorage extends WebDriverBase
+abstract class PHPWebDriver_WebDriverStorage extends PHPWebDriver_WebDriverBase
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
If you include the driver via `require_once 'PHPWebDriver/__init__.php';`

Then you get:

```
PHP Fatal error:  Class 'WebDriverBase' not found in .../WebDriverStorage.php on line 32
```

when you attempt to run your script. This is just because the class names have changed and a reference was missed in WebDriverStorage.php.

Fixes #9.
