### PR TITLE
is_a() check for WebDriverSession prevents access of nested elements

### DIFF
--- a/PHPWebDriver/WebDriverContainer.php
+++ b/PHPWebDriver/WebDriverContainer.php
@@ -51,13 +51,11 @@ abstract class PHPWebDriver_WebDriverContainer extends PHPWebDriver_WebDriverBas
 
   protected function webDriverElement($value) {
     if (array_key_exists('ELEMENT', (array) $value)) {
-      if (is_a($this, "PHPWebDriver_WebDriverSession")) {
-        return new PHPWebDriver_WebDriverElement(
-              $this->getElementPath($value['ELEMENT']), // url
-              $value['ELEMENT'],                        // id
-              $this                                     // session
-            );
-      }
+      return new PHPWebDriver_WebDriverElement(
+            $this->getElementPath($value['ELEMENT']), // url
+            $value['ELEMENT'],                        // id
+            $this                                     // session
+          );
     }
     return null;
   }


### PR DESCRIPTION
This check for the session object prevents you from nesting queries.

Consider the following html:

``` html
<table id="example">
    <tbody>
    <tr>
        <td>Row 1 Cell 1</td>
        <td>Row 1 Cell 2</td>
        <td>Row 1 Cell 3</td>
    </tr>
    <tr>
        <td>Row 2 Cell 1</td>
        <td>Row 2 Cell 2</td>
        <td>Row 2 Cell 3</td>
    </tr>
    <tr>
        <td>Row 3 Cell 1</td>
        <td>Row 3 Cell 2</td>
        <td>Row 3 Cell 3</td>
    </tr>
    </tbody>
</table>
```

Now lets loop through each row and handle the cells:

``` php
<?php
// successfully gets the rows
$rows = $session->elements("css selector", "table#example > tbody > tr");

foreach ($rows as $row) {
    // currently returns empty array due to
    // is_a($this, "PHPWebDriver_WebDriverSession") check
    // in WebDriverContainer::webDriverElement()
    $cells = $row->elements("css selector", "td");
}
```

The check isn't in the original Facebook driver - so I'm assuming it was added for a reason, but I can't work out why?
