### PR TITLE
Allowed switch_to_frame() to switch back to parent html

### DIFF
--- a/PHPWebDriver/WebDriverSession.php
+++ b/PHPWebDriver/WebDriverSession.php
@@ -196,6 +196,8 @@ class PHPWebDriver_WebDriverSession extends PHPWebDriver_WebDriverContainer {
   public function switch_to_frame($frame = null, $curl_opts = array()) {
     if (is_a($frame, "PHPWebDriver_WebDriverElement")) {
       $frame_id = array("id" => array("ELEMENT" => $frame->getId()));
+    } elseif ($frame == null) {
+      $frame_id = null;
     } else {
       throw new InvalidArgumentException('$frame needs to be a webdriver element of a frame');
     }

--- a/test/FrameTest.php
+++ b/test/FrameTest.php
@@ -26,6 +26,6 @@ class FrameTest extends PHPUnit_Framework_TestCase {
     $ps = self::$session->elements("css selector", "p");
     $this->assertEquals(count($ps), 6);
     // switch back
-    self::$session->frame();
+    self::$session->switch_to_frame();
   }
 }


### PR DESCRIPTION
 fixed switch_to_frame() function as it doesn't allow switching back to parent frame. $session->frame did but its better to standardize using switch_to_frame().
